### PR TITLE
Minimal typo fix to the binary number 0x20

### DIFF
--- a/output.md
+++ b/output.md
@@ -439,7 +439,7 @@ Checking if the transmit FIFO is empty can then be done from C:
      */
     int serial_is_transmit_fifo_empty(unsigned int com)
     {
-        /* 0x20 = 0001 0000 */
+        /* 0x20 = 0010 0000 */
         return inb(SERIAL_LINE_STATUS_PORT(com)) & 0x20;
     }
 ~~~


### PR DESCRIPTION
Stumbled across this typo when reading the book.
