### PR TITLE
Fix link.ld syntax

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -167,29 +167,29 @@ and memory-mapped I/O. Therefore, the following linker script is needed
 
 ~~~
     ENTRY(loader)           /* the name of the entry label */
+    SECTIONS {
+        . = 0x00100000;          /* the code should be loaded at 1 MB */
 
-    . = 0x00100000          /* the code should be loaded at 1 MB */
+        .text ALIGN (0x1000)    /* align at 4 KB */
+        {
+            *(.text)            /* all text sections from all files */
+        }
 
-    .text ALIGN (0x1000)    /* align at 4 KB */
-    {
-        *(.text)            /* all text sections from all files */
-    }
+        .rodata ALIGN (0x1000)  /* align at 4 KB */
+        {
+            *(.rodata*)         /* all read-only data sections from all files */
+        }
 
-    .rodata ALIGN (0x1000)  /* align at 4 KB */
-    {
-        *(.rodata*)         /* all read-only data sections from all files */
-    }
+        .data ALIGN (0x1000)    /* align at 4 KB */
+        {
+            *(.data)            /* all data sections from all files */
+        }
 
-    .data ALIGN (0x1000)    /* align at 4 KB */
-    {
-        *(.data)            /* all data sections from all files */
-    }
-
-    .bss ALIGN (0x1000)     /* align at 4 KB */
-    {
-        *(COMMON)           /* all COMMON sections from all files */
-        *(.bss)             /* all bss sections from all files */
-    }
+        .bss ALIGN (0x1000)     /* align at 4 KB */
+        {
+            *(COMMON)           /* all COMMON sections from all files */
+            *(.bss)             /* all bss sections from all files */
+        }
 ~~~
 
 Save the linker script into a file called `link.ld`. The executable can now be


### PR DESCRIPTION
closes #10

I am no OSDev expert (that is why I am reading the book!) but #10 showed this as the fix, so I thought it should be in the book.

this now works for me on CrunchBang ld version: `GNU ld (GNU Binutils for Debian) 2.24.51.20140918`

Thanks!