### PR TITLE
Add missing multiboot flags

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -132,11 +132,13 @@ describes how to set one up). Save the following code in a file called
     global loader                   ; the entry symbol for ELF
 
     MAGIC_NUMBER equ 0x1BADB002     ; define the magic number constant
-    CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum (magic number + checksum should equal 0)
+    FLAGS        equ 0x0            ; multiboot flags
+    CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum (magic number + checksum + flags should equal 0)
 
     section .text:                  ; start of the text (code) section
     align 4                         ; the code must be 4 byte aligned
-        dd MAGIC_NUMBER             ; write the magic number to the machine code
+        dd MAGIC_NUMBER             ; write the magic number to the machine code,
+        dd FLAGS                    ; the flags,
         dd CHECKSUM                 ; and the checksum
 
     loader:                         ; the loader label (defined as entry point in linker script)

--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -133,7 +133,8 @@ describes how to set one up). Save the following code in a file called
 
     MAGIC_NUMBER equ 0x1BADB002     ; define the magic number constant
     FLAGS        equ 0x0            ; multiboot flags
-    CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum (magic number + checksum + flags should equal 0)
+    CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum
+                                    ; (magic number + checksum + flags should equal 0)
 
     section .text:                  ; start of the text (code) section
     align 4                         ; the code must be 4 byte aligned


### PR DESCRIPTION
The current loader.s does not boot for me using bochs or qemu on Fedora
20. Adding FLAGS as documented in multiboot specification [1] fixes
this.

Without FLAGS, we get this error in qemu:

    $ qemu-system-i386 -cdrom os.iso
    Error 13: Invalid or unsupportd exectuable format

[1] http://www.gnu.org/software/grub/manual/multiboot/multiboot.html#boot_002eS