### PR TITLE
Fix text section

### DIFF
--- a/citation_style.csl
+++ b/citation_style.csl
@@ -38,7 +38,7 @@
       <else>
         <names variable="author">
             <name />
-        </name>
+        </names>
       </else>
     </choose>
   </macro>

--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -136,7 +136,7 @@ describes how to set one up). Save the following code in a file called
     CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum
                                     ; (magic number + checksum + flags should equal 0)
 
-    section .text:                  ; start of the text (code) section
+    section .text                   ; start of the text (code) section
     align 4                         ; the code must be 4 byte aligned
         dd MAGIC_NUMBER             ; write the magic number to the machine code,
         dd FLAGS                    ; the flags,

--- a/the_road_to_user_mode.md
+++ b/the_road_to_user_mode.md
@@ -62,7 +62,7 @@ bytes of the kernel - must be updated as follows:
     ; calculate the checksum (all options + checksum should equal 0)
     CHECKSUM        equ -(MAGIC_NUMBER + ALIGN_MODULES)
 
-    section .text:                      ; start of the text (code) section
+    section .text                       ; start of the text (code) section
     align 4                             ; the code must be 4 byte aligned
         dd MAGIC_NUMBER                 ; write the magic number
         dd ALIGN_MODULES                ; write the align modules instruction


### PR DESCRIPTION
The linker script won't match the text section if there's a colon after it. 

This causes random breakage if the multiboot header gets pushed out of the first 8kb of memory. 
