### PR TITLE
Fix bug in fb_write_cell

### DIFF
--- a/output.md
+++ b/output.md
@@ -94,8 +94,8 @@ The following code shows how this can be wrapped into a function:
      */
     void fb_write_cell(unsigned int i, char c, unsigned char fg, unsigned char bg)
     {
-        fb[i] = c;
-        fb[i + 1] = ((fg & 0x0F) << 4) | (bg & 0x0F)
+        fb[i * 2] = c;
+        fb[i * 2 + 1] = ((fg & 0x0F) << 4) | (bg & 0x0F)
     }
 ~~~
 


### PR DESCRIPTION
The example code for fb_write_cell incorrectly writes the character at framebuffer[i] and the formatting options to framebuffer[i + 1]. This leads to problems with repeated calls to fb_write_cell, e.g. a for loop inside of printf.

Repro:
fb_write_cell(0, 'A', 0, 1);
fb_write_cell(1, 'B', 0, 1);
fb_write_cell(2, 'C', 0, 1);

The second call would write 'B' over the formatting options for the character 'A' (that is, framebuffer[1]). In actuality, 'B' should be written to framebuffer[2], with B's formatting options in framebuffer[3].
