### PR TITLE
Fix: nasm external function declaration

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -93,8 +93,7 @@
 @misc{intel3a,
     author = "Intel",
     title = "Intel 64 and IA-32 Architectures Software Developer's Manual Vol. 3A",
-    url = "http://www.intel.com/content/
-www/us/en/architecture-and-technology/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.html/"
+    url = "http://www.intel.com/content/www/us/en/architecture-and-technology/64-ia-32-architectures-software-developer-vol-3a-part-1-manual.html"
 }
 
 @misc{ldcmdlang,

--- a/getting_to_c.md
+++ b/getting_to_c.md
@@ -69,7 +69,7 @@ rightmost argument first. The return value of the function is placed in the
 
 ~~~ {.nasm}
     ; The assembly code
-    external sum_of_three   ; the function sum_of_three is defined elsewhere
+    extern sum_of_three   ; the function sum_of_three is defined elsewhere
 
     push dword 3            ; arg3
     push dword 2            ; arg2


### PR DESCRIPTION
Using nasm version 2.10.09 gives an error if you specify an external C-function via the keyword "external" instead of "extern":
loader.S:6: error: parser: instruction expected
