### PR TITLE
Correct NASM macro syntax

### DIFF
--- a/interrupts.md
+++ b/interrupts.md
@@ -144,7 +144,7 @@ will be added as the "error code" for interrupts without an error code. The foll
 code shows an example of how this can be done:
 
 ~~~ {.nasm}
-    %macro no_error_code_interrupt_handler %1
+    %macro no_error_code_interrupt_handler 1
     global interrupt_handler_%1
     interrupt_handler_%1:
         push    dword 0                     ; push 0 as error code
@@ -152,7 +152,7 @@ code shows an example of how this can be done:
         jmp     common_interrupt_handler    ; jump to the common handler
     %endmacro
 
-    %macro error_code_interrupt_handler %1
+    %macro error_code_interrupt_handler 1
     global interrupt_handler_%1
     interrupt_handler_%1:
         push    dword %1                    ; push the interrupt number


### PR DESCRIPTION
As described currently, the proposed `nasm` code here would not compile for me. Multi-line macros expect a number of parameters (in which there is 1 for both macros here).
