### PR TITLE
Remove colon after section .text in loader.s

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -136,7 +136,7 @@ describes how to set one up). Save the following code in a file called
     CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum
                                     ; (magic number + checksum + flags should equal 0)
 
-    section .text:                  ; start of the text (code) section
+    section .text                   ; start of the text (code) section
     align 4                         ; the code must be 4 byte aligned
         dd MAGIC_NUMBER             ; write the magic number to the machine code,
         dd FLAGS                    ; the flags,


### PR DESCRIPTION
This causes an issue later on in section 4 when trying to create a driver for the frame buffer. Specifically, removing the colon fixes a problem with passing string in function calls. Refer to: http://stackoverflow.com/questions/28709256/error-13-invalid-or-unsupported-executable-while-booting-simple-kernel-in-grub . Not sure why, but this fixed it for me when I had the same issue.
