### PR TITLE
Fix link

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -80,8 +80,7 @@
 @misc{multiboot,
     author = "Free Software Foundation",
     title = "Multiboot Specification version 0.6.96",
-    url = "http://www.gnu.org/software/
-           grub/manual/multiboot/multiboot.html"
+    url = "http://www.gnu.org/software/grub/manual/multiboot/multiboot.html"
 }
 
 @misc{wiki:iso,


### PR DESCRIPTION
If I click on the link right now, I go to "https://www.gnu.org/software/%20%20%20%20%20%20%20%20%20%20%20grub/manual/multiboot/multiboot.html"
