### PR TITLE
Remove incorrect colon after "section .text"

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -136,7 +136,7 @@ describes how to set one up). Save the following code in a file called
     CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum
                                     ; (magic number + checksum + flags should equal 0)
 
-    section .text:                  ; start of the text (code) section
+    section .text                   ; start of the text (code) section
     align 4                         ; the code must be 4 byte aligned
         dd MAGIC_NUMBER             ; write the magic number to the machine code,
         dd FLAGS                    ; the flags,


### PR DESCRIPTION
Just a small typo fix, if I'm not mistaken.

Short background story:

I recently discovered this book, and went through the first few chapters without encountering any major technical issues (even though I'm on OS X, so I had to install NASM, an ELF cross-compiler build of GCC, and `mkisofs` with MacPorts). I'm currently in Chapter 4, and I decided to split up my code into multiple assembly and C files. But whenever I linked more than the original two `loader.o` and `kmain.o` object files together, GRUB would refuse to start the kernel and gave me an "invalid or unsupported executable format" error (error 13).

I searched for the error and found [this StackOverflow question](https://stackoverflow.com/questions/27939316/bochs-2-4-6-grub-0-97-error-13-invalid-or-unsupported-executable-format-wh) from someone also using this book. Their issue was slightly different, they got the error when using string literals in their C code. One of the answers pointed out the incorrect colon at the end of the `section .text:` line in the assembly code, which causes the section to be called `.text:` instead of `.text`. I removed the bad colon in my assembly files, and then GRUB accepted the kernel again and everything worked fine.