### PR TITLE
Fixed a broken link on UART/Serial programming

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -191,8 +191,7 @@
 @misc{wikibook:serial,
     author = "WikiBooks",
     title = "Serial Programming/8250 UART Programming",
-    url = "http://en.wikibooks.org/wiki/Serial_Programming/
-      8250_UART_Programming"
+    url = "https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming"
 }
 
 @misc{gnubinutils,


### PR DESCRIPTION
I noticed that the link for the UART wikibooks page was changed or otherwise broken, the correct one is https://en.wikibooks.org/wiki/Serial_Programming/8250_UART_Programming