### PR TITLE
fixed a problem into the loader

### DIFF
--- a/environment_and_booting.md
+++ b/environment_and_booting.md
@@ -136,7 +136,7 @@ describes how to set one up). Save the following code in a file called
     CHECKSUM     equ -MAGIC_NUMBER  ; calculate the checksum
                                     ; (magic number + checksum + flags should equal 0)
 
-    section .text:                  ; start of the text (code) section
+    section .text                   ; start of the text (code) section
     align 4                         ; the code must be 4 byte aligned
         dd MAGIC_NUMBER             ; write the magic number to the machine code,
         dd FLAGS                    ; the flags,


### PR DESCRIPTION
You have an extra colon at the end of section .text: so that creates a new section named .text: this section is emitted from the link.ld file and will cause a  Error 13: Invalid or unsupported executable while booting the operating system when add new features to the os (another person with my problem solved in the same way : https://stackoverflow.com/questions/28709256/error-13-invalid-or-unsupported-executable-while-booting-simple-kernel-in-grub)