### PR TITLE
Fix a problem Makefile (pandoc 2.11.0.2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ CITATION = citation_style.csl
 all: book.html
 
 book.html: $(CHAPTERS) $(CSS) $(HTML_TEMPLATE) $(BIB) $(CITATION)
-	pandoc -s -S --toc -c $(CSS) --template $(HTML_TEMPLATE) \
+	pandoc -s -f markdown+smart --toc -c $(CSS) --template $(HTML_TEMPLATE) \
 		   --bibliography $(BIB) --csl $(CITATION) --number-sections \
 		   $(CHAPTERS) -o $@
 
 book.pdf: $(CHAPTERS) $(TEX_HEADER) $(BIB) $(CITATION)
-	pandoc --toc -H $(TEX_HEADER) --latex-engine=pdflatex --chapters \
+	pandoc --toc -H $(TEX_HEADER) --pdf-engine=pdflatex --top-level-division=chapter \
 		   --no-highlight --bibliography $(BIB) --csl $(CITATION) \
 		   $(CHAPTERS) -o $@
 


### PR DESCRIPTION
A compilation error has occurred.

First, make

> pandoc -s -S --toc -c book.css --template template.html \
>            --bibliography bibliography.bib --csl citation_style.csl --number-sections \
>            title.txt introduction.md environment_and_booting.md getting_to_c.md output.md segmentation.md interrupts.md the_road_to_user_mode.md virtual_memory.md paging.md page_frame_allocation.md user_mode.md file_systems.md syscalls.md scheduling.md references.md -o book.html
> --smart/-S has been removed.  Use +smart or -smart extension instead.
> For example: pandoc -f markdown+smart -t markdown-smart.
> Try pandoc --help for more information.
> make: *** [Makefile:16: book.html] Error 6

Second, let's run make command after modified.

> owner@ubuntu:~/littleosbook$ make release
> pandoc --toc -H header.tex --latex-engine=pdflatex --chapters \
>            --no-highlight --bibliography bibliography.bib --csl citation_style.csl \
>            title.txt introduction.md environment_and_booting.md getting_to_c.md output.md segmentation.md interrupts.md the_road_to_user_mode.md virtual_memory.md paging.md page_frame_allocation.md user_mode.md file_systems.md syscalls.md scheduling.md references.md -o book.pdf
> --latex-engine has been removed.  Use --pdf-engine instead.
> --chapters has been removed. Use --top-level-division=chapter instead.
> Try pandoc --help for more information.
> make: *** [Makefile:21: book.pdf] Error 6
